### PR TITLE
Add intent.setPackage method

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Intent()
         ..putExtra(Extra.EXTRA_CC, ["jane.doe@exampleemail.com"]);
         ..putExtra(Extra.EXTRA_SUBJECT, "Foo bar");
         ..putExtra(Extra.EXTRA_TEXT, "Lorem ipsum");
+        ..startActivity().catchError((e) => print(e));
 ```
 
 ### Create a Document :

--- a/README.md
+++ b/README.md
@@ -122,6 +122,18 @@ Intent()
 ```
 It'll always be a wise decision to use `ACTION_DIAL`, because that won't require any kind of permissions.
 
+### Create Precomposed Email :
+```dart
+Intent()
+        ..setPackage("com.google.android.gm")
+        ..setAction(Action.ACTION_SEND);
+        ..setType("message/rfc822");
+        ..putExtra(Extra.EXTRA_EMAIL, ["john.doe@exampleemail.com"]);
+        ..putExtra(Extra.EXTRA_CC, ["jane.doe@exampleemail.com"]);
+        ..putExtra(Extra.EXTRA_SUBJECT, "Foo bar");
+        ..putExtra(Extra.EXTRA_TEXT, "Lorem ipsum");
+```
+
 ### Create a Document :
 Content type of document is set `text/plain`, category is `CATEGORY_OPENABLE` and file name is passed as an extra i.e. `EXTRA_TITLE`.
 ```dart

--- a/android/src/main/kotlin/io/github/itzmeanjan/intent/IntentPlugin.kt
+++ b/android/src/main/kotlin/io/github/itzmeanjan/intent/IntentPlugin.kt
@@ -88,6 +88,8 @@ class IntentPlugin(private val registrar: Registrar, private val activity: Activ
             "startActivity" -> {
                 val intent = Intent()
                 intent.action = call.argument<String>("action")
+                if (call.argument<String>("package") != null)
+                    intent.package = call.argument<String>("package")
                 if (call.argument<String>("data") != null)
                     intent.data = Uri.parse(call.argument<String>("data"))
                 call.argument<Map<String, Any>>("extra")?.apply {


### PR DESCRIPTION
Hello Anjan,
hello community

I added the `package` attribute to the `intent` object.
This should give us a `setPackage` method.

`setPackage(String packageName)` is used to suppress a chooser menu and open the intent with given app directly: [https://developer.android.com/reference/kotlin/android/content/Intent#setpackage](https://developer.android.com/reference/kotlin/android/content/Intent#setpackage)

See also the README for a concrete use case.

Could you please incorporate this change into your next release soon-ish? We need this feature for a go-live..

Thanks!
- Togi