### PR TITLE
Bugfix: escape package, as it's a Java keyword

### DIFF
--- a/android/src/main/kotlin/io/github/itzmeanjan/intent/IntentPlugin.kt
+++ b/android/src/main/kotlin/io/github/itzmeanjan/intent/IntentPlugin.kt
@@ -89,7 +89,7 @@ class IntentPlugin(private val registrar: Registrar, private val activity: Activ
                 val intent = Intent()
                 intent.action = call.argument<String>("action")
                 if (call.argument<String>("package") != null)
-                    intent.package = call.argument<String>("package")
+                    intent.`package` = call.argument<String>("package")
                 if (call.argument<String>("data") != null)
                     intent.data = Uri.parse(call.argument<String>("data"))
                 call.argument<Map<String, Any>>("extra")?.apply {


### PR DESCRIPTION
Hey Anjan,

I'm sorry, I made a mistake. I'm not a Kotlin developer.
`package` is a reserved keyword in Java and therefore should be escaped in Kotlin.
In the current version, there could be trouble compiling the Kotlin code.

Also described here:
[https://subscription.packtpub.com/book/application_development/9781788472142/1/ch01lvl1sec19/escaping-for-java-identifiers-that-are-keywords-in-kotlin](https://subscription.packtpub.com/book/application_development/9781788472142/1/ch01lvl1sec19/escaping-for-java-identifiers-that-are-keywords-in-kotlin)

Thank you again for your efforts and your super quick response!